### PR TITLE
Failed on release build

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -194,15 +194,15 @@ dependencies {
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
-    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+    implementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'
     }
 
-    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+    implementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
 
-    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+    implementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
 


### PR DESCRIPTION
I tried to create a new project with the template and do a release build, but got the following errors:

```shell
$ ./gradlew bundleRelease

> Task :app:compileReleaseJavaWithJavac FAILED
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:10: error: package com.facebook.flipper.android does not exist
import com.facebook.flipper.android.AndroidFlipperClient;
                                   ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:11: error: package com.facebook.flipper.android.utils does not exist
import com.facebook.flipper.android.utils.FlipperUtils;
                                         ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:12: error: package com.facebook.flipper.core does not exist
import com.facebook.flipper.core.FlipperClient;
                                ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:13: error: package com.facebook.flipper.plugins.crashreporter does not exist
import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin;
                                                 ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:14: error: package com.facebook.flipper.plugins.databases does not exist
import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin;
                                             ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:15: error: package com.facebook.flipper.plugins.fresco does not exist
import com.facebook.flipper.plugins.fresco.FrescoFlipperPlugin;
                                          ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:16: error: package com.facebook.flipper.plugins.inspector does not exist
import com.facebook.flipper.plugins.inspector.DescriptorMapping;
                                             ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:17: error: package com.facebook.flipper.plugins.inspector does not exist
import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
                                             ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:18: error: package com.facebook.flipper.plugins.network does not exist
import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
                                           ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:19: error: package com.facebook.flipper.plugins.network does not exist
import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
                                           ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:20: error: package com.facebook.flipper.plugins.react does not exist
import com.facebook.flipper.plugins.react.ReactFlipperPlugin;
                                         ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:21: error: package com.facebook.flipper.plugins.sharedpreferences does not exist
import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin;
                                                     ^
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:29: error: cannot find symbol
    if (FlipperUtils.shouldEnableFlipper(context)) {
        ^
  symbol:   variable FlipperUtils
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:30: error: cannot find symbol
      final FlipperClient client = AndroidFlipperClient.getInstance(context);
            ^
  symbol:   class FlipperClient
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:30: error: cannot find symbol
      final FlipperClient client = AndroidFlipperClient.getInstance(context);
                                   ^
  symbol:   variable AndroidFlipperClient
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:32: error: cannot find symbol
      client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
                           ^
  symbol:   class InspectorFlipperPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:32: error: cannot find symbol
      client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
                                                           ^
  symbol:   variable DescriptorMapping
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:33: error: cannot find symbol
      client.addPlugin(new ReactFlipperPlugin());
                           ^
  symbol:   class ReactFlipperPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:34: error: cannot find symbol
      client.addPlugin(new DatabasesFlipperPlugin(context));
                           ^
  symbol:   class DatabasesFlipperPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:35: error: cannot find symbol
      client.addPlugin(new SharedPreferencesFlipperPlugin(context));
                           ^
  symbol:   class SharedPreferencesFlipperPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:36: error: cannot find symbol
      client.addPlugin(CrashReporterPlugin.getInstance());
                       ^
  symbol:   variable CrashReporterPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:38: error: cannot find symbol
      NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
      ^
  symbol:   class NetworkFlipperPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:38: error: cannot find symbol
      NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
                                                      ^
  symbol:   class NetworkFlipperPlugin
  location: class ReactNativeFlipper
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:43: error: cannot find symbol
              builder.addNetworkInterceptor(new FlipperOkhttpInterceptor(networkFlipperPlugin));
                                                ^
  symbol: class FlipperOkhttpInterceptor
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:62: error: cannot find symbol
                        client.addPlugin(new FrescoFlipperPlugin());
                                             ^
  symbol: class FrescoFlipperPlugin
/Users/me/src/code/r/reasonml/MyApp/android/app/src/main/java/com/myapp/ReactNativeFlipper.java:68: error: cannot find symbol
        client.addPlugin(new FrescoFlipperPlugin());
                             ^
  symbol:   class FrescoFlipperPlugin
  location: class ReactNativeFlipper
26 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 17s
19 actionable tasks: 10 executed, 9 up-to-date
```

It seems Gradle is complaining about dependencies on Flipper.  Changing all three dependency declarations on Flipper in `android/app/build.gradle` from `debugImplementation` to `implementation` fixed it.  Note that I am a total newbie in React Native AND Android development here :)
